### PR TITLE
fix rolex_rolex_1 start fail, update the environment

### DIFF
--- a/release/install.sh
+++ b/release/install.sh
@@ -31,5 +31,5 @@ curl -sSL  ${CRANE_TAR_URL} | tar xvzf -
 echo "Enter IP address that your want bind Crane service [ENTER]"
 read listener_ip
 
-cd crane && CRANE_IP=${listener_ip} VERSION=${CRANE_RELEASE} REGISTRY_PREFIX=${REGISTRY_PREFIX} ./deploy.sh
+cd crane && ROLEX_IP=${listener_ip} VERSION=${CRANE_RELEASE} REGISTRY_PREFIX=${REGISTRY_PREFIX} ./deploy.sh
 cd -


### PR DESCRIPTION
when install crane, one of the containers called rolex_rolex_1 start fail. To see the code, find the reason is the ROLEX_SWARM_MANAGER_IP environment.