### PR TITLE
fixed misspell

### DIFF
--- a/src/dockerclient/stack.go
+++ b/src/dockerclient/stack.go
@@ -55,7 +55,7 @@ func (client *CraneDockerClient) DeployStack(bundle *model.Bundle) error {
 }
 
 // before deploy stack we must verify all service spec params and check port conflict
-// aslo we need check networks used by all of the servcie if the network is not existed
+// also we need check networks used by all of the servcie if the network is not existed
 // created the network by the default param(network driver --overlay)
 func (client *CraneDockerClient) PretreatmentStack(bundle model.Bundle) (map[string]bool, error) {
 	// create network map and convert to slice for distinct network

--- a/src/plugins/tty/context.go
+++ b/src/plugins/tty/context.go
@@ -250,7 +250,7 @@ func (ctx *ClientContext) processReceive() {
 		}
 
 		if len(data) == 0 {
-			log.Error("An error has occured")
+			log.Error("An error has occurred")
 			return
 		}
 


### PR DESCRIPTION
Misspell Finds commonly misspelled English words
crane/src/plugins/tty/context.go
Line 253: warning: found "occured" a misspelling of "occurred" (misspell)
crane/src/dockerclient/stack.go
Line 58: warning: found "aslo" a misspelling of "also" (misspell)