### PR TITLE
Optimize the service/stack/network name regular expression according to the Docker official naming convention

### DIFF
--- a/frontend/src/network/create/create.html
+++ b/frontend/src/network/create/create.html
@@ -4,7 +4,7 @@
         <div class="form-control">
             <input id="net-create-name" type="text" data-ng-model="networkCreateCtrl.form.Name" focus-me
                    data-required="required" name="name"
-                   data-ng-pattern="/^[A-Za-z0-9]+$/">
+                   data-ng-pattern="/^\w[\w_.-]+\w$/">
         </div>
         <div ng-messages="createNetwork.name.$error" ng-if="createNetwork.name.$dirty" role="alert">
             <p class="help-text"

--- a/frontend/src/network/create/create.html
+++ b/frontend/src/network/create/create.html
@@ -4,7 +4,7 @@
         <div class="form-control">
             <input id="net-create-name" type="text" data-ng-model="networkCreateCtrl.form.Name" focus-me
                    data-required="required" name="name"
-                   data-ng-pattern="/^\w[\w_.-]+\w$/">
+                   data-ng-pattern="/^\w[\w_.-]*\w$/">
         </div>
         <div ng-messages="createNetwork.name.$error" ng-if="createNetwork.name.$dirty" role="alert">
             <p class="help-text"

--- a/frontend/src/node/create-network/create.html
+++ b/frontend/src/node/create-network/create.html
@@ -7,7 +7,7 @@
         <div class="form-control">
             <input id="node-network-name" type="text" data-ng-model="nodeCreateNetworkCtrl.form.Name"
                    data-required="required" name="name"
-                   data-ng-pattern="/^[A-Za-z0-9]+$/">
+                   data-ng-pattern="/^\w[\w_.-]+\w$/">
         </div>
         <div ng-messages="createSingleNetwork.name.$error" ng-if="createSingleNetwork.name.$dirty" role="alert">
             <p class="help-text"

--- a/frontend/src/node/create-volume/create.html
+++ b/frontend/src/node/create-volume/create.html
@@ -7,7 +7,7 @@
         <div class="form-control">
             <input id="node-add-name" type="text" name="name"
                    data-ng-model="nodeCreateVolumeCtrl.form.Name"
-                   data-ng-pattern="/^[A-Za-z0-9]+$/"
+                   data-ng-pattern="/^\w[\w_.-]+\w$/"
                    data-required="required">
         </div>
         <div ng-messages="createVolume.name.$error" ng-if="createVolume.name.$dirty"

--- a/frontend/src/registry/create-update-catalog/create-update.html
+++ b/frontend/src/registry/create-update-catalog/create-update.html
@@ -5,7 +5,7 @@
         </label>
         <div class="form-control">
             <input id="image-catalog-name" type="text" data-ng-model="createUpdateCatalog.form.Name" data-required="required" name="Name"
-                   data-ng-pattern="/^[A-Za-z0-9]+$/" focus-me>
+                   data-ng-pattern="/^\w[\w_.-]+\w$/" focus-me>
         </div>
         <div ng-messages="staticForm.Name.$error" ng-if="staticForm.Name.$dirty" role="alert">
             <p class="text-danger help-text" ng-message="required">{/'Name field is required' | translate/}</p>

--- a/frontend/src/stack/create/create-by-Json.html
+++ b/frontend/src/stack/create/create-by-Json.html
@@ -6,7 +6,7 @@
         <div class="form-control">
             <input id="json-create-Namespace" type="text" data-ng-model="stackCreateByJsonCtrl.form.Namespace"
                    data-required="required" name="Name"
-                   data-ng-pattern="/^[A-Za-z0-9]+$/" focus-me>
+                   data-ng-pattern="/^\w[\w_.-]+\w$/" focus-me>
         </div>
         <div ng-messages="staticForm.Name.$error" ng-if="staticForm.Name.$dirty" role="alert">
             <p class="text-danger help-text" ng-message="required">{/'Name field is required' | translate/}</p>

--- a/frontend/src/stack/create/create-by-Json.html
+++ b/frontend/src/stack/create/create-by-Json.html
@@ -6,7 +6,7 @@
         <div class="form-control">
             <input id="json-create-Namespace" type="text" data-ng-model="stackCreateByJsonCtrl.form.Namespace"
                    data-required="required" name="Name"
-                   data-ng-pattern="/^\w[\w_.-]+\w$/" focus-me>
+                   data-ng-pattern="/^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$/" focus-me>
         </div>
         <div ng-messages="staticForm.Name.$error" ng-if="staticForm.Name.$dirty" role="alert">
             <p class="text-danger help-text" ng-message="required">{/'Name field is required' | translate/}</p>

--- a/frontend/src/stack/create/create-by-form.html
+++ b/frontend/src/stack/create/create-by-form.html
@@ -10,7 +10,7 @@
             <div class="form-control">
                 <input id="createByForm-Namespace" type="text" data-ng-model="stackCreateByFormCtrl.form.Namespace"
                        data-required="required" name="Name" focus-me
-                       data-ng-pattern="/^\w[\w_.-]+\w$/">
+                       data-ng-pattern="/^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$/">
             </div>
             <div ng-messages="stepOneForm.Name.$error" ng-if="stepOneForm.Name.$dirty"
                  role="alert">
@@ -49,7 +49,7 @@
                         <div class="form-control">
                             <input id="service{/$index/}-Name" type="text" data-ng-model="serve.Name"
                                    data-required="required" name="name"
-                                   data-ng-pattern="/^\w[\w_.-]+\w$/"
+                                   data-ng-pattern="/^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$/"
                                    dm-check-include="stackCreateByFormCtrl.listNames($index)">
                         </div>
                         <div ng-messages="staticForm.name.$error" ng-if="staticForm.name.$dirty"

--- a/frontend/src/stack/create/create-by-form.html
+++ b/frontend/src/stack/create/create-by-form.html
@@ -10,7 +10,7 @@
             <div class="form-control">
                 <input id="createByForm-Namespace" type="text" data-ng-model="stackCreateByFormCtrl.form.Namespace"
                        data-required="required" name="Name" focus-me
-                       data-ng-pattern="/^[A-Za-z0-9]+$/">
+                       data-ng-pattern="/^\w[\w_.-]+\w$/">
             </div>
             <div ng-messages="stepOneForm.Name.$error" ng-if="stepOneForm.Name.$dirty"
                  role="alert">
@@ -49,7 +49,7 @@
                         <div class="form-control">
                             <input id="service{/$index/}-Name" type="text" data-ng-model="serve.Name"
                                    data-required="required" name="name"
-                                   data-ng-pattern="/^[A-Za-z0-9]+$/"
+                                   data-ng-pattern="/^\w[\w_.-]+\w$/"
                                    dm-check-include="stackCreateByFormCtrl.listNames($index)">
                         </div>
                         <div ng-messages="staticForm.name.$error" ng-if="staticForm.name.$dirty"


### PR DESCRIPTION
In some complex services, only use letters and numbers can not clearly describe the purpose of the service. With reference to Docker official service name regular expression, allowing service name contains [.-_] these three special characters.